### PR TITLE
Update Ouster-2 params

### DIFF
--- a/av_ouster_launch/params/av_ouster_config.yaml
+++ b/av_ouster_launch/params/av_ouster_config.yaml
@@ -25,7 +25,7 @@
     # - TIME_FROM_ROS_TIME: This option uses the time of reception of first
     #                       packet of a LidarScan as the timestamp of the IMU,
     #                       PointCloud2 and LaserScan messages.
-    timestamp_mode: 'TIME_FROM_ROS_TIME'
+    timestamp_mode: 'TIME_FROM_SYNC_PULSE_IN'
     # ptp_utc_tai_offset[optional]: UTC/TAI offset in seconds to apply when
     # TIME_FROM_PTP_1588 timestamp mode is used.
     ptp_utc_tai_offset: -37.0
@@ -35,7 +35,7 @@
     # - RNG15_RFL8_NIR8
     # - RNG19_RFL8_SIG16_NIR16_DUAL
     # - FUSA_RNG15_RFL8_NIR8_DUAL
-    udp_profile_lidar: 'LEGACY'
+    udp_profile_lidar: 'RNG19_RFL8_SIG16_NIR16'
     # metadata[optional]: path to save metadata file to, if left empty a file
     # with the sensor hostname or ip will be crearted in ~/.ros folder.
     metadata: ''
@@ -86,4 +86,4 @@
     # - ouster_ros/os_point.h
     # - ouster_ros/sensor_point_types.h
     # - ouster_ros/common_point_types.h.
-    point_type: xyzi
+    point_type: original


### PR DESCRIPTION
 - Use `TIME_FROM_SYNC_PULSE_IN` to use NMEA timestamp for pointclouds
 - Switch to non-deprecated `RNG19_RFL8_SIG16_NIR16` udp profile
 - Revert to full point_type "original" as we need `xyzirt`