### PR TITLE
Define lidar/imu ports to avoid random port assignment

### DIFF
--- a/av_ouster_launch/CHANGELOG.rst
+++ b/av_ouster_launch/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package av_ouster_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Define lidar/imu ports to avoid random port assignment
+  - Set LIDAR and IMU ports to `1500` and `1501` respectively
+* Contributors: Hector Cruz
+
 2.4.0 (2024-10-11)
 ------------------
 * Add ros_time argument to set GPS/PPS time synch

--- a/av_ouster_launch/params/av_ouster_config.yaml
+++ b/av_ouster_launch/params/av_ouster_config.yaml
@@ -42,11 +42,11 @@
     # lidar_port[optional]: port value should be in the range [0, 65535]. If you
     # use 0 as the port value then the first available port number will be
     # assigned.
-    lidar_port: 0
+    lidar_port: 1500
     # imu_port[optional]: port value should be in the range [0, 65535]. If you
     # use 0 as the port value then the first available port number will be
     # assigned.
-    imu_port: 0
+    imu_port: 1501
     # sensor_frame[optional]: name to use when referring to the sensor frame.
     sensor_frame: lidar_ouster_top
     # lidar_frame[optional]: name to use when referring to the lidar frame.


### PR DESCRIPTION
- Set LIDAR and IMU ports to `1500` and `1501` respectively