### PR TITLE
Fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
         apt-get -y --quiet --no-install-recommends install \
         git \
         ros-"$ROS_DISTRO"-pcl-ros \
-        ros-"$ROS_DISTRO"-tf2-eigen \
+        ros-"$ROS_DISTRO"-tf2* \
         # Install Cyclone DDS ROS RMW
         ros-"$ROS_DISTRO"-rmw-cyclonedds-cpp \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Avoid upgrading `ros-humble-tf2-eigen` individually to prevent version discrepancies between TF2 package libraries and potential build errors. Instead, install the entire suite of TF2 ROS packages.